### PR TITLE
Fix typo in ember-concurrency docs

### DIFF
--- a/reactiveweb/src/ember-concurrency.ts
+++ b/reactiveweb/src/ember-concurrency.ts
@@ -43,7 +43,6 @@ import { DEFAULT_THUNK, normalizeThunk } from './utils.ts';
  *  {{this.last.value}}
  *  {{this.last.isFinished}}
  *  {{this.last.isRunning}}
- *  {{this.last.value}}
  * ```
  *  (and all other properties on a [TaskInstance](https://ember-concurrency.com/api/TaskInstance.html))
  *


### PR DESCRIPTION
Ported from https://github.com/NullVoxPopuli/ember-resources/pull/1067