### PR TITLE
Upgrade test-apps to ember-resources@6.5.1 to test against deprecations

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,8 +172,8 @@ importers:
         specifier: ^3.1.1
         version: 3.1.1(@babel/core@7.23.7)(ember-source@3.28.12)
       ember-resources:
-        specifier: ^6.4.2
-        version: 6.4.2(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.2.1)(ember-concurrency@3.1.1)(ember-source@3.28.12)
+        specifier: ^6.5.1
+        version: 6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.2.1)(ember-concurrency@3.1.1)(ember-source@3.28.12)
       msw:
         specifier: ^1.3.2
         version: 1.3.2(typescript@5.2.2)
@@ -365,8 +365,8 @@ importers:
         specifier: ^3.1.1
         version: 3.1.1(@babel/core@7.23.7)(ember-source@5.4.0)
       ember-resources:
-        specifier: ^6.4.2
-        version: 6.4.2(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.2.1)(ember-concurrency@3.1.1)(ember-source@5.4.0)
+        specifier: ^6.5.1
+        version: 6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.2.1)(ember-concurrency@3.1.1)(ember-source@5.4.0)
       msw:
         specifier: ^1.3.2
         version: 1.3.2(typescript@5.2.2)
@@ -7954,66 +7954,6 @@ packages:
       - supports-color
     dev: true
 
-  /ember-resources@6.4.2(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.2.1)(ember-concurrency@3.1.1)(ember-source@3.28.12):
-    resolution: {integrity: sha512-B1OLdSpekdiyk/yfHc+aJF3ovI6rskwJOLzd+iX60RTyicO9Nsjw8LU9XI95uk4AOqO0MbSXogQ/MsN/mIPzOw==}
-    peerDependencies:
-      '@ember/test-waiters': ^3.0.0
-      '@glimmer/component': ^1.1.2
-      '@glimmer/tracking': ^1.1.2
-      '@glint/template': ^1.0.0-beta.3 || ^1.0.0
-      ember-concurrency: ^2.0.0 || ^3.0.0
-      ember-source: '*'
-    peerDependenciesMeta:
-      '@ember/test-waiters':
-        optional: true
-      '@glimmer/component':
-        optional: true
-      ember-concurrency:
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.23.2
-      '@ember/test-waiters': 3.1.0
-      '@embroider/addon-shim': 1.8.7
-      '@embroider/macros': 1.13.4(@glint/template@1.2.1)
-      '@glimmer/component': 1.1.2(@babel/core@7.23.7)
-      '@glimmer/tracking': 1.1.2
-      '@glint/template': 1.2.1
-      ember-async-data: 1.0.3(ember-source@3.28.12)
-      ember-concurrency: 3.1.1(@babel/core@7.23.7)(ember-source@3.28.12)
-      ember-source: 3.28.12(@babel/core@7.23.7)
-    transitivePeerDependencies:
-      - supports-color
-
-  /ember-resources@6.4.2(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.2.1)(ember-concurrency@3.1.1)(ember-source@5.4.0):
-    resolution: {integrity: sha512-B1OLdSpekdiyk/yfHc+aJF3ovI6rskwJOLzd+iX60RTyicO9Nsjw8LU9XI95uk4AOqO0MbSXogQ/MsN/mIPzOw==}
-    peerDependencies:
-      '@ember/test-waiters': ^3.0.0
-      '@glimmer/component': ^1.1.2
-      '@glimmer/tracking': ^1.1.2
-      '@glint/template': ^1.0.0-beta.3 || ^1.0.0
-      ember-concurrency: ^2.0.0 || ^3.0.0
-      ember-source: '*'
-    peerDependenciesMeta:
-      '@ember/test-waiters':
-        optional: true
-      '@glimmer/component':
-        optional: true
-      ember-concurrency:
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.23.2
-      '@ember/test-waiters': 3.1.0
-      '@embroider/addon-shim': 1.8.7
-      '@embroider/macros': 1.13.4(@glint/template@1.2.1)
-      '@glimmer/component': 1.1.2(@babel/core@7.23.7)
-      '@glimmer/tracking': 1.1.2
-      '@glint/template': 1.2.1
-      ember-async-data: 1.0.3(ember-source@5.4.0)
-      ember-concurrency: 3.1.1(@babel/core@7.23.7)(ember-source@5.4.0)
-      ember-source: 5.4.0(@babel/core@7.23.7)(@glimmer/component@1.1.2)(@glint/template@1.2.1)(webpack@5.89.0)
-    transitivePeerDependencies:
-      - supports-color
-
   /ember-resources@6.4.2(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.2.1)(ember-source@5.5.0):
     resolution: {integrity: sha512-B1OLdSpekdiyk/yfHc+aJF3ovI6rskwJOLzd+iX60RTyicO9Nsjw8LU9XI95uk4AOqO0MbSXogQ/MsN/mIPzOw==}
     peerDependencies:
@@ -8043,6 +7983,66 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
+
+  /ember-resources@6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.2.1)(ember-concurrency@3.1.1)(ember-source@3.28.12):
+    resolution: {integrity: sha512-8eEdbSE0sioqjpB2CWw/dKF4Ftfe9tbebuSUfMDBmP3xxTIvxTDbvDnbd8A0IbQ0z/iQt6Va+/5cadzvkbMZtg==}
+    peerDependencies:
+      '@ember/test-waiters': ^3.0.0
+      '@glimmer/component': ^1.1.2
+      '@glimmer/tracking': ^1.1.2
+      '@glint/template': ^1.0.0-beta.3 || ^1.0.0
+      ember-concurrency: ^2.0.0 || ^3.0.0
+      ember-source: '*'
+    peerDependenciesMeta:
+      '@ember/test-waiters':
+        optional: true
+      '@glimmer/component':
+        optional: true
+      ember-concurrency:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@ember/test-waiters': 3.1.0
+      '@embroider/addon-shim': 1.8.7
+      '@embroider/macros': 1.13.4(@glint/template@1.2.1)
+      '@glimmer/component': 1.1.2(@babel/core@7.23.7)
+      '@glimmer/tracking': 1.1.2
+      '@glint/template': 1.2.1
+      ember-async-data: 1.0.3(ember-source@3.28.12)
+      ember-concurrency: 3.1.1(@babel/core@7.23.7)(ember-source@3.28.12)
+      ember-source: 3.28.12(@babel/core@7.23.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  /ember-resources@6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.2.1)(ember-concurrency@3.1.1)(ember-source@5.4.0):
+    resolution: {integrity: sha512-8eEdbSE0sioqjpB2CWw/dKF4Ftfe9tbebuSUfMDBmP3xxTIvxTDbvDnbd8A0IbQ0z/iQt6Va+/5cadzvkbMZtg==}
+    peerDependencies:
+      '@ember/test-waiters': ^3.0.0
+      '@glimmer/component': ^1.1.2
+      '@glimmer/tracking': ^1.1.2
+      '@glint/template': ^1.0.0-beta.3 || ^1.0.0
+      ember-concurrency: ^2.0.0 || ^3.0.0
+      ember-source: '*'
+    peerDependenciesMeta:
+      '@ember/test-waiters':
+        optional: true
+      '@glimmer/component':
+        optional: true
+      ember-concurrency:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@ember/test-waiters': 3.1.0
+      '@embroider/addon-shim': 1.8.7
+      '@embroider/macros': 1.13.4(@glint/template@1.2.1)
+      '@glimmer/component': 1.1.2(@babel/core@7.23.7)
+      '@glimmer/tracking': 1.1.2
+      '@glint/template': 1.2.1
+      ember-async-data: 1.0.3(ember-source@5.4.0)
+      ember-concurrency: 3.1.1(@babel/core@7.23.7)(ember-source@5.4.0)
+      ember-source: 5.4.0(@babel/core@7.23.7)(@glimmer/component@1.1.2)(@glint/template@1.2.1)(webpack@5.89.0)
+    transitivePeerDependencies:
+      - supports-color
 
   /ember-rfc176-data@0.3.18:
     resolution: {integrity: sha512-JtuLoYGSjay1W3MQAxt3eINWXNYYQliK90tLwtb8aeCuQK8zKGCRbBodVIrkcTqshULMnRuTOS6t1P7oQk3g6Q==}
@@ -15723,7 +15723,7 @@ packages:
       '@embroider/addon-shim': 1.8.7
       '@embroider/macros': 1.13.4(@glint/template@1.2.1)
       ember-async-data: 1.0.3(ember-source@3.28.12)
-      ember-resources: 6.4.2(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.2.1)(ember-concurrency@3.1.1)(ember-source@3.28.12)
+      ember-resources: 6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.2.1)(ember-concurrency@3.1.1)(ember-source@3.28.12)
       ember-source: 3.28.12(@babel/core@7.23.7)
     transitivePeerDependencies:
       - '@glimmer/component'
@@ -15745,7 +15745,7 @@ packages:
       '@embroider/addon-shim': 1.8.7
       '@embroider/macros': 1.13.4(@glint/template@1.2.1)
       ember-async-data: 1.0.3(ember-source@5.4.0)
-      ember-resources: 6.4.2(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.2.1)(ember-concurrency@3.1.1)(ember-source@5.4.0)
+      ember-resources: 6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.2.1)(ember-concurrency@3.1.1)(ember-source@5.4.0)
       ember-source: 5.4.0(@babel/core@7.23.7)(@glimmer/component@1.1.2)(@glint/template@1.2.1)(webpack@5.89.0)
     transitivePeerDependencies:
       - '@glimmer/component'

--- a/tests/min-supported/package.json
+++ b/tests/min-supported/package.json
@@ -99,7 +99,7 @@
     "@ember/test-waiters": "^3.1.0",
     "@nullvoxpopuli/eslint-configs": "^3.2.2",
     "ember-concurrency": "^3.1.1",
-    "ember-resources": "^6.4.2",
+    "ember-resources": "^6.5.1",
     "msw": "^1.3.2"
   },
   "msw": {

--- a/tests/test-app/package.json
+++ b/tests/test-app/package.json
@@ -101,7 +101,7 @@
     "@embroider/macros": "^1.13.4",
     "@nullvoxpopuli/eslint-configs": "^3.2.2",
     "ember-concurrency": "^3.1.1",
-    "ember-resources": "^6.4.2",
+    "ember-resources": "^6.5.1",
     "msw": "^1.3.2"
   },
   "msw": {


### PR DESCRIPTION
This PR will be red, have CI failing, but this is on purpose so that that the changelog generator can appropriately point out what's changed in the next version, as it only uses PR titles.