### PR TITLE
Refactor the map util to not be a resource, it never needed to be

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: wyvox/action-setup-pnpm@v3
+      - run: pnpm build
+      - run: pnpm i -f # re sync injected deps
       - run: pnpm lint
 
   test:

--- a/reactiveweb/src/map.ts
+++ b/reactiveweb/src/map.ts
@@ -172,7 +172,7 @@ export function map<Elements extends readonly unknown[], MapTo = unknown>(
      * - if iterating over part of the data, map will only be called for the elements observed
      * - if not iterating, map will only be called for the elements observed.
      */
-    map: (element: Elements[number]) => MapTo;
+    map: (element: Elements[0]) => MapTo;
   }
 ): MappedArray<Elements, MapTo> {
   let { data, map } = options;

--- a/reactiveweb/src/map.ts
+++ b/reactiveweb/src/map.ts
@@ -215,23 +215,20 @@ export class TrackedArrayMap<Element = unknown, MappedTo = unknown>
      *
      * Maybe JS has a way to implement array-index access, but I don't know how
      */
-    return new Proxy(
-      this,
-      {
-        get(_target, property) {
-          if (typeof property === 'string') {
-            let parsed = parseInt(property, 10);
+    return new Proxy(this, {
+      get(_target, property) {
+        if (typeof property === 'string') {
+          let parsed = parseInt(property, 10);
 
-            if (!isNaN(parsed)) {
-              return self[AT](parsed);
-            }
+          if (!isNaN(parsed)) {
+            return self[AT](parsed);
           }
+        }
 
-          return self[property as keyof MappedArray<Element[], MappedTo>];
-        },
-        // Is there a way to do this without lying to TypeScript?
-      }
-    ) as TrackedArrayMap<Element, MappedTo>;
+        return self[property as keyof MappedArray<Element[], MappedTo>];
+      },
+      // Is there a way to do this without lying to TypeScript?
+    }) as TrackedArrayMap<Element, MappedTo>;
   }
 
   @cached

--- a/tests/test-app/tests/utils/map/js-test.ts
+++ b/tests/test-app/tests/utils/map/js-test.ts
@@ -33,7 +33,7 @@ module('Utils | map | js', function (hooks) {
   for (let variant of [
     {
       name: 'public api',
-      getItem: (collection: Wrapper[], index: number) => collection[index],
+      getItem: (collection: any, index: number) => collection[index],
     },
     {
       name: 'private api (sanity check)',


### PR DESCRIPTION
This resolves the deprecation where Map previously extended a class-based resource.