### PR TITLE
docs: correct import lines in code example

### DIFF
--- a/reactiveweb/src/keep-latest.ts
+++ b/reactiveweb/src/keep-latest.ts
@@ -42,8 +42,8 @@ interface Options<T = unknown> {
  * To smooth that out, we can use [[keepLatest]]
  *
  * ```js
- *  import { RemoteData } from 'ember-resources/util/remote-data';
- *  import { keepLatest } from 'ember-resources/util/keep-latest';
+ *  import { RemoteData } from 'reactiveweb/remote-data';
+ *  import { keepLatest } from 'reactiveweb/keep-latest';
  *
  *  class A {
  *    @use request = RemoteData(() => 'some url');
@@ -61,8 +61,8 @@ interface Options<T = unknown> {
  *
  * To specify a default value, use an additional getter
  * ```js
- *  import { RemoteData } from 'ember-resources/util/remote-data';
- *  import { keepLatest } from 'ember-resources/util/keep-latest';
+ *  import { RemoteData } from 'reactiveweb/remote-data';
+ *  import { keepLatest } from 'reactiveweb/keep-latest';
  *
  *  class A {
  *    @use request = RemoteData(() => 'some url');

--- a/tests/test-app/tests/resources/modifier-test.gts
+++ b/tests/test-app/tests/resources/modifier-test.gts
@@ -3,7 +3,7 @@ import { render, settled } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 
-import { cell,resource } from 'ember-resources';
+import { cell, resource } from 'ember-resources';
 import { modifier } from 'reactiveweb/resource/modifier';
 
 module('modifier | rendering', function (hooks) {

--- a/tests/test-app/tests/resources/service-test.gts
+++ b/tests/test-app/tests/resources/service-test.gts
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { find,render } from '@ember/test-helpers';
+import { find, render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 

--- a/tests/test-app/tests/utils/function/rendering-test.gts
+++ b/tests/test-app/tests/utils/function/rendering-test.gts
@@ -6,7 +6,7 @@ import { click, render, settled } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 
-import { resource, resourceFactory,use } from 'ember-resources';
+import { resource, resourceFactory, use } from 'ember-resources';
 import { trackedFunction } from 'reactiveweb/function';
 
 const timeout = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));


### PR DESCRIPTION
Just noticed this import line hadn't been updated in the reactiveweb API docs (awesome btw). Looks like it's generated from this comment