### PR TITLE
Add functionality to make debounce not return undefined initially

### DIFF
--- a/reactiveweb/src/debounce.ts
+++ b/reactiveweb/src/debounce.ts
@@ -58,16 +58,26 @@ class TrackedValue<T> {
  * @param {number} ms delay in milliseconds to wait before updating the returned value
  * @param {() => Value} thunk function that returns the value to debounce
  */
-export function debounce<Value = unknown>(ms: number, thunk: () => Value) {
+export function debounce<Value = unknown>(ms: number, thunk: () => Value, debounceInitialValue = true) {
   let lastValue: Value;
   let timer: number;
   let state = new TrackedValue<Value>();
 
+  /**
+   * Whether the initial value has been returned inmediately or not
+   */
+  let initialValueReturned = debounceInitialValue;
+
   return resource(({ on }) => {
     lastValue = thunk();
 
-    on.cleanup(() => timer && clearTimeout(timer));
-    timer = setTimeout(() => (state.value = lastValue), ms);
+    if (!initialValueReturned) {
+      state.value = lastValue;
+      initialValueReturned = true;
+    } else {
+      on.cleanup(() => timer && clearTimeout(timer));
+      timer = setTimeout(() => (state.value = lastValue), ms);
+    }
 
     return state.value;
   });

--- a/reactiveweb/src/debounce.ts
+++ b/reactiveweb/src/debounce.ts
@@ -58,7 +58,11 @@ class TrackedValue<T> {
  * @param {number} ms delay in milliseconds to wait before updating the returned value
  * @param {() => Value} thunk function that returns the value to debounce
  */
-export function debounce<Value = unknown>(ms: number, thunk: () => Value, debounceInitialValue = true) {
+export function debounce<Value = unknown>(
+  ms: number,
+  thunk: () => Value,
+  debounceInitialValue = true
+) {
   let lastValue: Value;
   let timer: number;
   let state = new TrackedValue<Value>();

--- a/tests/test-app/tests/utils/debounce/rendering-test.gts
+++ b/tests/test-app/tests/utils/debounce/rendering-test.gts
@@ -1,0 +1,44 @@
+import { tracked } from '@glimmer/tracking';
+import { render } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+
+import { use } from 'ember-resources';
+import { debounce } from 'reactiveweb/debounce';
+
+module('Utils | debounce | rendering', function (hooks) {
+  setupRenderingTest(hooks);
+
+  let someTime = (ms = 25) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  module('debounce', function () {
+    test('without debouncing the initial value', async function (assert) {
+      class Test {
+        @tracked text = 'someValue';
+        @use debouncedText = debounce(100, () => this.text, false);
+      }
+
+      let foo = new Test();
+
+      await render(<template>
+        {{log foo.debouncedText}}
+        {{foo.debouncedText}}
+        </template>);
+
+      assert.dom().hasText('someValue');
+
+      foo.text = 'newValue';
+
+      // Change is not inmediately reflected
+      assert.dom().hasText('someValue');
+
+      // Change is also not reflected after 50ms
+      await someTime(50);
+      assert.dom().hasText('someValue');
+
+      // Change is reflected after 100ms (50+50)
+      await someTime(50);
+      assert.dom().hasText('newValue');
+    });
+  });
+});

--- a/tests/test-app/tests/utils/debounce/rendering-test.gts
+++ b/tests/test-app/tests/utils/debounce/rendering-test.gts
@@ -21,7 +21,6 @@ module('Utils | debounce | rendering', function (hooks) {
       let foo = new Test();
 
       await render(<template>
-        {{log foo.debouncedText}}
         {{foo.debouncedText}}
         </template>);
 


### PR DESCRIPTION
## Summary 
I want the debounce function to intially return a value, and debounce all changes after that.

## Details 
I added a third optional argument to debounce `debounceInitialValue` which is true by default.
When you set this to false, the initial value will be returned on resource creation. Otherwise, the initial value will only be returned after `ms` milliseconds.

I added a rendering test to make sure it works properly.