### PR TITLE
[trackedFunction]: fix error handling so Glimmer does die when an error is thrown

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:ember": "pnpm --filter '*' test:ember"
   },
   "devDependencies": {
+    "@glint/core": "^1.2.1",
     "concurrently": "^8.2.2",
     "prettier": "^3.0.3",
     "prettier-plugin-ember-template-tag": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     devDependencies:
+      '@glint/core':
+        specifier: ^1.2.1
+        version: 1.2.1(typescript@5.2.2)
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2

--- a/tests/test-app/tests/utils/function/better-error-handling-test.gts
+++ b/tests/test-app/tests/utils/function/better-error-handling-test.gts
@@ -1,0 +1,151 @@
+
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { render, settled } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+
+import { trackedFunction } from 'reactiveweb/function';
+
+const asString = (x: unknown) => `${x}`;
+
+module('Utils | trackedFunction | rendering w/errors', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it catches errors', async function (assert) {
+    class TestComponent extends Component {
+      data = trackedFunction(this, () => {
+        throw new Error('Never resolves successfully');
+      });
+
+      <template>
+         state: {{this.data.state}}
+         isSettled: {{this.data.isSettled}}
+         isError: {{this.data.isError}}
+         isRejected: {{this.data.isRejected}}
+         error: {{asString this.data.error}}
+      </template>
+    }
+
+    await render(<template><TestComponent /></template>);
+
+    assert.dom().hasText('state: UNSTARTED isSettled: true isError: true isRejected: true error: Error: Never resolves successfully');
+  });
+
+  test('it can resume with non-error after an error', async function (assert) {
+
+class State {
+  @tracked doError = true;
+}
+
+    let state = new State();
+let i = 0;
+
+    class TestComponent extends Component {
+      doError = true;
+
+      data = trackedFunction(this, async () => {
+assert.step(`call:${i++}`);
+
+
+        if (state.doError) {
+          throw new Error('oh no');
+        }
+
+        return 'success';
+      });
+
+      <template>
+         state: {{this.data.state}}
+         isSettled: {{this.data.isSettled}}
+         isError: {{this.data.isError}}
+         isRejected: {{this.data.isRejected}}
+         error: {{asString this.data.error}}
+         value: {{asString this.data.value}}
+      </template>
+    }
+
+    await render(<template><TestComponent /></template>);
+
+assert.dom().hasText('state: REJECTED isSettled: true isError: true isRejected: true error: Error: oh no value: null');
+
+assert.verifySteps(['call:0']);
+
+state.doError = false;
+await settled();
+
+assert.verifySteps(['call:1']);
+assert.dom().hasText('state: RESOLVED isSettled: true isError: false isRejected: false error: null value: success');
+  });
+
+  test('after an await, it catches errors', async function (assert) {
+    class TestComponent extends Component {
+      data = trackedFunction(this, async () => {
+        await Promise.resolve();
+        throw new Error('Never resolves successfully');
+      });
+
+      <template>
+         state: {{this.data.state}}
+         isSettled: {{this.data.isSettled}}
+         isError: {{this.data.isError}}
+         isRejected: {{this.data.isRejected}}
+         error: {{asString this.data.error}}
+      </template>
+    }
+
+    await render(<template><TestComponent /></template>);
+
+
+    assert.dom().hasText('state: REJECTED isSettled: true isError: true isRejected: true error: Error: Never resolves successfully');
+  });
+
+  test('after an await, it can resume with non-error after an error', async function (assert) {
+
+class State {
+  @tracked doError = true;
+}
+
+    let state = new State();
+let i = 0;
+
+    class TestComponent extends Component {
+      doError = true;
+
+      data = trackedFunction(this, async () => {
+assert.step(`call:${i++}`);
+
+
+        if (state.doError) {
+          await Promise.resolve();
+          throw new Error('oh no');
+        }
+
+          await Promise.resolve();
+
+        return 'success';
+      });
+
+      <template>
+         state: {{this.data.state}}
+         isSettled: {{this.data.isSettled}}
+         isError: {{this.data.isError}}
+         isRejected: {{this.data.isRejected}}
+         error: {{asString this.data.error}}
+         value: {{asString this.data.value}}
+      </template>
+    }
+
+    await render(<template><TestComponent /></template>);
+
+assert.dom().hasText('state: REJECTED isSettled: true isError: true isRejected: true error: Error: oh no value: null');
+
+assert.verifySteps(['call:0']);
+
+state.doError = false;
+await settled();
+
+assert.verifySteps(['call:1']);
+assert.dom().hasText('state: RESOLVED isSettled: true isError: false isRejected: false error: null value: success');
+  });
+});


### PR DESCRIPTION
See also: https://github.com/qunitjs/qunit/issues/1736

ember-async-data's error handling isn't enough, as it turns out:

https://github.com/tracked-tools/ember-async-data/blob/main/ember-async-data/src/tracked-async-data.ts#L57

so here adds a try/catch with reactive state handling.