### PR TITLE
Add debounce initialize

### DIFF
--- a/reactiveweb/src/debounce.ts
+++ b/reactiveweb/src/debounce.ts
@@ -1,10 +1,4 @@
-import { tracked } from '@glimmer/tracking';
-
-import { resource } from 'ember-resources';
-
-class TrackedValue<T> {
-  @tracked value: T | undefined;
-}
+import { cell, resource } from 'ember-resources';
 
 /**
  * A utility for debouncing high-frequency updates.
@@ -78,9 +72,7 @@ class TrackedValue<T> {
  */
 export function debounce<Value = unknown>(ms: number, thunk: () => Value, initialize?: Value) {
   let lastValue: Value | undefined = initialize;
-  let state = new TrackedValue<Value>();
-
-  state.value = lastValue;
+  let state = cell<Value | undefined>(lastValue);
 
   return resource(({ on }) => {
     let timer: number;
@@ -94,9 +86,9 @@ export function debounce<Value = unknown>(ms: number, thunk: () => Value, initia
     });
 
     timer = setTimeout(() => {
-      state.value = lastValue;
+      state.current = lastValue;
     }, ms);
 
-    return () => state.value;
+    return () => state.current;
   });
 }

--- a/reactiveweb/src/debounce.ts
+++ b/reactiveweb/src/debounce.ts
@@ -9,7 +9,7 @@ class TrackedValue<T> {
 /**
  * A utility for debouncing high-frequency updates.
  * The returned value will only be updated every `ms` and is
- * initially undefined.
+ * initially undefined, unless an initialize value is provided.
  *
  * This can be useful when a user's typing is updating a tracked
  * property and you want to derive data less frequently than on
@@ -57,10 +57,13 @@ class TrackedValue<T> {
  *
  * @param {number} ms delay in milliseconds to wait before updating the returned value
  * @param {() => Value} thunk function that returns the value to debounce
+ * @param {Value} initialize value to return initially before any debounced updates
  */
-export function debounce<Value = unknown>(ms: number, thunk: () => Value) {
-  let lastValue: Value;
+export function debounce<Value = unknown>(ms: number, thunk: () => Value, initialize?: Value) {
+  let lastValue: Value | undefined = initialize;
   let state = new TrackedValue<Value>();
+
+  state.value = lastValue;
 
   return resource(({ on }) => {
     let timer: number;

--- a/reactiveweb/src/debounce.ts
+++ b/reactiveweb/src/debounce.ts
@@ -54,7 +54,7 @@ class TrackedValue<T> {
  *    @use search = RemoteData(() => `https://my.domain/search?q=${this.debouncedInput}`);
  *  }
  * ```
- * 
+ *
  * @example
  * An initialize value can be provided as the starting value instead of it initially returning undefined.
  * ```js

--- a/reactiveweb/src/debounce.ts
+++ b/reactiveweb/src/debounce.ts
@@ -54,6 +54,23 @@ class TrackedValue<T> {
  *    @use search = RemoteData(() => `https://my.domain/search?q=${this.debouncedInput}`);
  *  }
  * ```
+ * 
+ * @example
+ * An initialize value can be provided as the starting value instead of it initially returning undefined.
+ * ```js
+ *  import Component from '@glimmer/component';
+ *  import { tracked } from '@glimmer/tracking';
+ *  import { use } from 'ember-resources';
+ *  import { debounce } from 'reactiveweb/debounce';
+ *
+ *  const delay = 100; // ms
+ *
+ *  class Demo extends Component {
+ *    @tracked userInput = 'products';
+ *
+ *    @use debouncedInput = debounce(delay, () => this.userInput, this.userInput);
+ *  }
+ * ```
  *
  * @param {number} ms delay in milliseconds to wait before updating the returned value
  * @param {() => Value} thunk function that returns the value to debounce

--- a/tests/test-app/tests/utils/debounce/js-test.ts
+++ b/tests/test-app/tests/utils/debounce/js-test.ts
@@ -40,35 +40,28 @@ module('Utils | debounce | js', function (hooks) {
 
     test('initialize value', async function (assert) {
       class Test {
-        @tracked data = 'start';
+        @tracked value = 'initial';
 
-        @use text = debounce(100, () => this.data, this.data);
+        @use debouncedValue = debounce(100, () => this.value, this.value);
       }
 
       let test = new Test();
 
       setOwner(test, this.owner);
 
-      assert.strictEqual(test.text, 'start');
+      assert.strictEqual(test.debouncedValue, 'initial', 'Value is as given at first');
 
-      test.data = 'b';
-      await someTime();
-      assert.strictEqual(test.text, 'start');
-      test.data = 'bo';
-      await someTime();
-      assert.strictEqual(test.text, 'start');
-      test.data = 'boo';
-      await someTime();
-      assert.strictEqual(test.text, 'start');
+      test.value = 'new'
 
-      await someTime(110);
-      assert.strictEqual(test.text, 'boo');
+      assert.notEqual(test.debouncedValue, test.value, 'Value and debounced value have diverged')
 
-      test.data = 'boop';
-      assert.strictEqual(test.text, 'boo');
+      await timeout(50);
 
-      await someTime(110);
-      assert.strictEqual(test.text, 'boop');
+      assert.strictEqual(test.debouncedValue, 'initial', 'Value is still initial after ~50ms');
+
+      await timeout(50);
+
+      assert.strictEqual(test.debouncedValue, 'new', `Value is updated after ~100ms`);
     });
   });
 });

--- a/tests/test-app/tests/utils/debounce/js-test.ts
+++ b/tests/test-app/tests/utils/debounce/js-test.ts
@@ -37,5 +37,38 @@ module('Utils | debounce | js', function (hooks) {
         `Value is "${test.debouncedValue}" after ~100ms`
       );
     });
+
+    test('initialize value', async function (assert) {
+      class Test {
+        @tracked data = 'start';
+
+        @use text = debounce(100, () => this.data, this.data);
+      }
+
+      let test = new Test();
+
+      setOwner(test, this.owner);
+
+      assert.strictEqual(test.text, 'start');
+
+      test.data = 'b';
+      await someTime();
+      assert.strictEqual(test.text, 'start');
+      test.data = 'bo';
+      await someTime();
+      assert.strictEqual(test.text, 'start');
+      test.data = 'boo';
+      await someTime();
+      assert.strictEqual(test.text, 'start');
+
+      await someTime(110);
+      assert.strictEqual(test.text, 'boo');
+
+      test.data = 'boop';
+      assert.strictEqual(test.text, 'boo');
+
+      await someTime(110);
+      assert.strictEqual(test.text, 'boop');
+    });
   });
 });

--- a/tests/test-app/tests/utils/debounce/js-test.ts
+++ b/tests/test-app/tests/utils/debounce/js-test.ts
@@ -51,9 +51,9 @@ module('Utils | debounce | js', function (hooks) {
 
       assert.strictEqual(test.debouncedValue, 'initial', 'Value is as given at first');
 
-      test.value = 'new'
+      test.value = 'new';
 
-      assert.notEqual(test.debouncedValue, test.value, 'Value and debounced value have diverged')
+      assert.notEqual(test.debouncedValue, test.value, 'Value and debounced value have diverged');
 
       await timeout(50);
 


### PR DESCRIPTION
## Summary 
This should be pretty straightforward

My use case is I'm looking to use debounce to avoid some UI states changing too quickly based on tracked data (causing a loading spinner to flash for a split second before showing data, that kind of thing)

But I would like it to show the current state on render (eg loading) without waiting, and only debounce updates to that state.
