### PR TITLE
Widen test matrix to include ember-source 5.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
           - ember-lts-4.8
           - ember-lts-4.12
           - ember-lts-5.4
+          - ember-lts-5.8
           - ember-concurrency-4.0
           - ember-release
           - ember-beta

--- a/tests/test-app/config/ember-try.js
+++ b/tests/test-app/config/ember-try.js
@@ -42,6 +42,14 @@ module.exports = async function () {
         },
       },
       {
+        name: 'ember-lts-5.8',
+        npm: {
+          devDependencies: {
+            'ember-source': '~5.8.0',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {


### PR DESCRIPTION
Supersedes: https://github.com/universal-ember/reactiveweb/pull/109
Fixes: https://github.com/universal-ember/reactiveweb/issues/110 