### PR TITLE
Add meta to the trackedFunction callback

### DIFF
--- a/reactiveweb/src/function.ts
+++ b/reactiveweb/src/function.ts
@@ -56,6 +56,7 @@ export function trackedFunction<Return>(
   fn: (meta: {
     /**
      * true when state.retry() is called, false initially
+     * and also false when tracked data changes (new initial)
      */
     isRetrying: boolean;
   }) => Return
@@ -107,6 +108,7 @@ export function trackedFunction<Return>(
   fn: (meta: {
     /**
      * true when state.retry() is called, false initially
+     * and also false when tracked data changes (new initial)
      */
     isRetrying: boolean;
   }) => Return
@@ -146,7 +148,7 @@ function directTrackedFunction<Return>(context: object, fn: (meta: CallbackMeta)
   const state = new State(fn);
 
   let destroyable = resource<State<Return>>(context, () => {
-    state.retry();
+    state[START]();
 
     return state;
   });

--- a/tests/test-app/package.json
+++ b/tests/test-app/package.json
@@ -92,7 +92,7 @@
     "webpack": "^5.89.0"
   },
   "engines": {
-    "node": "16.* || >= 18"
+    "node": ">= 22"
   },
   "ember": {
     "edition": "octane"

--- a/tests/test-app/tests/utils/function/rendering-test.gts
+++ b/tests/test-app/tests/utils/function/rendering-test.gts
@@ -18,7 +18,9 @@ module('Utils | trackedFunction | rendering', function (hooks) {
     class TestComponent extends Component {
       @tracked count = 1;
 
-      data = trackedFunction(this, () => {
+      data = trackedFunction(this, ({ isRetrying }) => {
+        assert.step(`${isRetrying}`);
+
         return this.count;
       });
       increment = () => this.count++;
@@ -32,10 +34,12 @@ module('Utils | trackedFunction | rendering', function (hooks) {
     await render(<template><TestComponent /></template>);
 
     assert.dom('out').hasText('1');
+    assert.verifySteps(['false']);
 
     await click('button');
 
     assert.dom('out').hasText('2');
+    assert.verifySteps(['false']);
   });
 
   test('it is retryable', async function (assert) {
@@ -61,12 +65,12 @@ module('Utils | trackedFunction | rendering', function (hooks) {
     }
 
     await render(<template><TestComponent /></template>);
-    assert.verifySteps(['ran trackedFunction 0']);
+    assert.verifySteps(['ran trackedFunction 0 & false']);
 
     assert.dom('out').hasText('0');
 
     await click('button');
-    assert.verifySteps(['ran trackedFunction 1']);
+    assert.verifySteps(['ran trackedFunction 1 & true']);
 
     assert.dom('out').hasText('1');
 

--- a/tests/test-app/tests/utils/function/rendering-test.gts
+++ b/tests/test-app/tests/utils/function/rendering-test.gts
@@ -42,14 +42,14 @@ module('Utils | trackedFunction | rendering', function (hooks) {
     let count = 0;
 
     class TestComponent extends Component {
-      data = trackedFunction(this, () => {
+      data = trackedFunction(this, ({ isRetrying }) => {
         // Copy the count so asynchrony of trackedFunction evaluation
         // doesn't return a newer value than existed at the time
         // of the function invocation.
         let localCount = count;
 
         count++;
-        assert.step(`ran trackedFunction ${localCount}`);
+        assert.step(`ran trackedFunction ${localCount} & ${isRetrying}`);
 
         return localCount;
       });


### PR DESCRIPTION
This enables better interop with ember-data and other things that may have a cache policy based on whether or not the data is needed initially, or subsequently.

non-breaking.