### PR TITLE
Keeping 3.28+ support, but remove the cached-decorator polyfill

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,9 +65,6 @@ importers:
       ember-async-data:
         specifier: ^1.0.3 || >=2.0.0
         version: 1.0.3(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.25.7))(@glint/template@1.4.0)(rsvp@4.8.5))
-      ember-cached-decorator-polyfill:
-        specifier: ^1.0.2
-        version: 1.0.2(@babel/core@7.25.7)(@glint/template@1.4.0)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.25.7))(@glint/template@1.4.0)(rsvp@4.8.5))
       ember-resources:
         specifier: '>= 6.4.2'
         version: 6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2(@babel/core@7.25.7))(@glimmer/tracking@1.1.2)(@glint/template@1.4.0)(ember-concurrency@3.1.1(@babel/core@7.25.7)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.25.7))(@glint/template@1.4.0)(rsvp@4.8.5)))(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.25.7))(@glint/template@1.4.0)(rsvp@4.8.5))
@@ -12646,34 +12643,6 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  ember-cached-decorator-polyfill@1.0.2(@babel/core@7.25.7)(@glint/template@1.4.0)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.25.7))(@glint/template@1.4.0)(rsvp@4.8.5)):
-    dependencies:
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
-      '@glimmer/tracking': 1.1.2
-      babel-import-util: 1.4.1
-      ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.25.7)
-      ember-cli-babel: 7.26.11
-      ember-cli-babel-plugin-helpers: 1.1.1
-      ember-source: 5.12.0(@glimmer/component@1.1.2(@babel/core@7.25.7))(@glint/template@1.4.0)(rsvp@4.8.5)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
-  ember-cached-decorator-polyfill@1.0.2(@babel/core@7.25.7)(@glint/template@1.4.0)(ember-source@5.4.1(@babel/core@7.25.7)(@glimmer/component@1.1.2(@babel/core@7.25.7))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.94.0)):
-    dependencies:
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
-      '@glimmer/tracking': 1.1.2
-      babel-import-util: 1.4.1
-      ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.25.7)
-      ember-cli-babel: 7.26.11
-      ember-cli-babel-plugin-helpers: 1.1.1
-      ember-source: 5.4.1(@babel/core@7.25.7)(@glimmer/component@1.1.2(@babel/core@7.25.7))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.94.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
   ember-cli-app-version@6.0.1(ember-source@3.28.12(@babel/core@7.25.7)):
     dependencies:
       ember-cli-babel: 7.26.11
@@ -16744,7 +16713,6 @@ snapshots:
       '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       decorator-transforms: 2.2.2(@babel/core@7.25.7)
       ember-async-data: 1.0.3(ember-source@3.28.12(@babel/core@7.25.7))
-      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.25.7)(@glint/template@1.4.0)(ember-source@3.28.12(@babel/core@7.25.7))
       ember-resources: 6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2(@babel/core@7.25.7))(@glimmer/tracking@1.1.2)(@glint/template@1.4.0)(ember-concurrency@3.1.1(@babel/core@7.25.7)(ember-source@3.28.12(@babel/core@7.25.7)))(ember-source@3.28.12(@babel/core@7.25.7))
       ember-source: 3.28.12(@babel/core@7.25.7)
     transitivePeerDependencies:
@@ -16762,7 +16730,6 @@ snapshots:
       '@embroider/macros': 1.16.6(@glint/template@1.4.0)
       decorator-transforms: 2.2.2(@babel/core@7.25.7)
       ember-async-data: 1.0.3(ember-source@5.4.1(@babel/core@7.25.7)(@glimmer/component@1.1.2(@babel/core@7.25.7))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.94.0))
-      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.25.7)(@glint/template@1.4.0)(ember-source@5.4.1(@babel/core@7.25.7)(@glimmer/component@1.1.2(@babel/core@7.25.7))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.94.0))
       ember-resources: 6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2(@babel/core@7.25.7))(@glimmer/tracking@1.1.2)(@glint/template@1.4.0)(ember-concurrency@3.1.1(@babel/core@7.25.7)(ember-source@5.4.1(@babel/core@7.25.7)(@glimmer/component@1.1.2(@babel/core@7.25.7))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.94.0)))(ember-source@5.4.1(@babel/core@7.25.7)(@glimmer/component@1.1.2(@babel/core@7.25.7))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.94.0))
       ember-source: 5.4.1(@babel/core@7.25.7)(@glimmer/component@1.1.2(@babel/core@7.25.7))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.94.0)
     transitivePeerDependencies:

--- a/reactiveweb/package.json
+++ b/reactiveweb/package.json
@@ -62,7 +62,6 @@
     "@embroider/macros": "^1.16.6",
     "decorator-transforms": "^2.2.2",
     "ember-async-data": "^1.0.3 || >=2.0.0",
-    "ember-cached-decorator-polyfill": "^1.0.2",
     "ember-resources": ">= 6.4.2"
   },
   "devDependencies": {

--- a/reactiveweb/src/-private/ember-compat.ts
+++ b/reactiveweb/src/-private/ember-compat.ts
@@ -1,0 +1,24 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { dependencySatisfies, importSync, macroCondition } from '@embroider/macros';
+
+import type Owner from '@ember/owner';
+
+interface CompatOwner {
+  getOwner: (context: unknown) => Owner | undefined;
+  setOwner: (context: unknown, owner: Owner) => void;
+}
+
+export const compatOwner = {} as CompatOwner;
+
+if (macroCondition(dependencySatisfies('ember-source', '>=4.12.0'))) {
+  // In no version of ember where `@ember/owner` tried to be imported did it exist
+  // if (macroCondition(false)) {
+  // Using 'any' here because importSync can't lookup types correctly
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  compatOwner.getOwner = (importSync('@ember/owner') as any).getOwner;
+  compatOwner.setOwner = (importSync('@ember/owner') as any).setOwner;
+} else {
+  // Using 'any' here because importSync can't lookup types correctly
+  compatOwner.getOwner = (importSync('@ember/application') as any).getOwner;
+  compatOwner.setOwner = (importSync('@ember/application') as any).setOwner;
+}

--- a/reactiveweb/src/link.ts
+++ b/reactiveweb/src/link.ts
@@ -1,9 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { getOwner, setOwner } from '@ember/application';
 import { assert } from '@ember/debug';
 import { associateDestroyableChild } from '@ember/destroyable';
 
+import { compatOwner } from './-private/ember-compat.ts';
+
 import type { Class, Stage1Decorator, Stage1DecoratorDescriptor } from '#types';
+
+let getOwner = compatOwner.getOwner;
+let setOwner = compatOwner.setOwner;
 
 type NonKey<K> = K extends string ? never : K extends symbol ? never : K;
 

--- a/reactiveweb/src/map.ts
+++ b/reactiveweb/src/map.ts
@@ -1,6 +1,9 @@
-import { cached } from '@glimmer/tracking';
-import { setOwner } from '@ember/application';
+import { createCache, getValue } from '@glimmer/tracking/primitives/cache';
 import { assert } from '@ember/debug';
+
+import { compatOwner } from './-private/ember-compat.ts';
+
+const setOwner = compatOwner.setOwner;
 
 /**
  * Public API of the return value of the [[map]] utility.
@@ -231,8 +234,11 @@ export class TrackedArrayMap<Element = unknown, MappedTo = unknown>
     }) as TrackedArrayMap<Element, MappedTo>;
   }
 
-  @cached
-  get _records(): (Element & object)[] {
+  /**
+   * We don't want to use @cached
+   * because we support 3.28, and @cached was introduced in 4.1-4.5
+   */
+  #records = createCache(() => {
     let data = this._dataFn();
 
     assert(
@@ -241,6 +247,10 @@ export class TrackedArrayMap<Element = unknown, MappedTo = unknown>
     );
 
     return data as Array<Element & object>;
+  });
+
+  get _records(): (Element & object)[] {
+    return getValue(this.#records) as (Element & object)[];
   }
 
   values = () => [...this];

--- a/reactiveweb/src/resource/service.ts
+++ b/reactiveweb/src/resource/service.ts
@@ -3,28 +3,14 @@ import { getValue } from '@glimmer/tracking/primitives/cache';
 import { assert } from '@ember/debug';
 import { associateDestroyableChild } from '@ember/destroyable';
 import { invokeHelper } from '@ember/helper';
-import {
-  dependencySatisfies,
-  importSync,
-  isDevelopingApp,
-  isTesting,
-  macroCondition,
-} from '@embroider/macros';
+import { isDevelopingApp, isTesting, macroCondition } from '@embroider/macros';
+
+import { compatOwner } from '../-private/ember-compat.ts';
 
 import type Owner from '@ember/owner';
 import type { Stage1DecoratorDescriptor } from '#types';
 
-let getOwner: (context: unknown) => Owner | undefined;
-
-if (macroCondition(dependencySatisfies('ember-source', '>=4.12.0'))) {
-  // Using 'any' here because importSync can't lookup types correctly
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getOwner = (importSync('@ember/owner') as any).getOwner;
-} else {
-  // Using 'any' here because importSync can't lookup types correctly
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getOwner = (importSync('@ember/application') as any).getOwner;
-}
+let getOwner = compatOwner.getOwner;
 
 /**
  * In order for the same cache to be used for all references


### PR DESCRIPTION
`@cached` was only used in one spot, so I decided to use `@cached` underlying primitives instead. much simpler.

Also fixes some deprecations on ember 4.12+


Marked as bugfix for newer projects -- would be no-op for older projects.