### PR TITLE
Remove unneeded peers

### DIFF
--- a/reactiveweb/package.json
+++ b/reactiveweb/package.json
@@ -110,7 +110,6 @@
     "main": "addon-main.cjs"
   },
   "peerDependencies": {
-    "@ember/test-waiters": ">= 3.1.0",
-    "ember-source": ">= 3.28.0"
+    "@ember/test-waiters": ">= 3.1.0"
   }
 }


### PR DESCRIPTION
embroider, auto-import, and ember-cli before them handled virtual deps without a package.json entry.

package.json entries win over virtual deps, so we don't want to declare ember-source or @glimmer/tracking as peers.


Related:
- https://github.com/NullVoxPopuli/ember-resources/pull/1189
- https://github.com/universal-ember/kolay/pull/187
- https://github.com/universal-ember/ember-primitives/pull/471