### PR TITLE
make `trackedTask` infer the return type correctly

### DIFF
--- a/reactiveweb/src/ember-concurrency.ts
+++ b/reactiveweb/src/ember-concurrency.ts
@@ -45,6 +45,12 @@ import { DEFAULT_THUNK, normalizeThunk } from './utils.ts';
  *
  *
  */
+export function task<LocalTask extends TaskIsh<unknown[], unknown> = TaskIsh<unknown[], unknown>>(
+  context: object,
+  task: LocalTask,
+  thunk?: () => unknown[]
+): TaskInstance<TaskReturnType<LocalTask>>;
+
 export function task<
   Return = unknown,
   Args extends unknown[] = unknown[],


### PR DESCRIPTION
fixes https://github.com/universal-ember/reactiveweb/issues/84

- typeScript infers generics left to right. Return appears first, but nothing in the parameter positions directly constrains it — it only appears indirectly inside the constraint of LocalTask. TypeScript can't "reverse-infer" Return from LocalTask's constraint, so it falls back to the default unknown
- the fix is add an overload that removes Return and Args as independent generics and instead extract them from LocalTask using conditional types