### PR TITLE
Check for `!== undefined` to avoid treating `false` as not resolved

### DIFF
--- a/reactiveweb/src/function.ts
+++ b/reactiveweb/src/function.ts
@@ -190,7 +190,7 @@ export class State<Value> {
       return 'PENDING';
     }
 
-    if (this.#state.resolved) {
+    if (this.#state.resolved !== undefined) {
       return 'RESOLVED';
     }
 
@@ -235,7 +235,7 @@ export class State<Value> {
    * When true, the function passed to `trackedFunction` has resolved
    */
   get isResolved() {
-    return Boolean(this.#state.resolved);
+    return this.#state.resolved !== undefined;
   }
 
   /**

--- a/tests/test-app/tests/utils/function/state-test.ts
+++ b/tests/test-app/tests/utils/function/state-test.ts
@@ -107,4 +107,37 @@ module('Utils | trackedFunction | State | js', function (hooks) {
     m = 'isPending';
     assert.false(state.isPending, m);
   });
+
+  test('resolving to false', async function (assert) {
+    let m = '<invalid state>';
+    let resolve: (value?: unknown) => void;
+
+    const promise = new Promise((r) => {
+      resolve = r;
+    });
+
+    const value = false;
+
+    const state = new State(() => promise);
+    const promise2 = state.retry();
+
+    // @ts-ignore This is normal promise usage
+    resolve(value);
+    await promise2;
+
+    m = 'isResolved';
+    assert.true(state.isResolved, m);
+
+    m = 'isRejected';
+    assert.false(state.isRejected, m);
+
+    m = 'error';
+    assert.strictEqual(state.error, null, m);
+
+    m = 'value';
+    assert.strictEqual(state.value, value, m);
+
+    m = 'isPending';
+    assert.false(state.isPending, m);
+  });
 });


### PR DESCRIPTION
I came across an issue with `trackedFunction` wrapping a function that returns `Promise<boolean>`. The `State` class' `state()` getter and the `isResolved()` method were both mistakenly treating a falsy value as 'not resolved'. Since the internals return `undefined` before the promise resolves, I replaced the logic with a `!== undefined` check. This would still fail if the wrapped function returns `Promise<truthy | undefined>`, but at least this handles `false` or `null` and does not modify any other behaviour.